### PR TITLE
Update Dockerfile to use NodeJS version 12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.16-alpine
+FROM node:12-alpine
 
 WORKDIR /srv/wikidocumentaries-api
 


### PR DESCRIPTION
This should fix the error "certificate has expired", see https://meta.wikimedia.org/wiki/HTTPS/2021_Let%27s_Encrypt_root_expiry